### PR TITLE
Added Validation to Compare RHEL version with the expected RHEL version in the pipeline

### DIFF
--- a/ansible_image_validation/validate-vm-images.yaml
+++ b/ansible_image_validation/validate-vm-images.yaml
@@ -16,6 +16,7 @@
     - assert:
         that:
           - "offer_type is defined"
+          - "rhel_version is defined"
 
     - set_fact:
         rhui_regions: "{{ lookup('file', 'files/rhui-regions').split() }}"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -17,6 +17,14 @@
 #     fi
 #   ignore_errors: yes
 
+- name: Compare RHEL version with the expected RHEL version in the pipeline
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "RHEL version mismatch: Expected RHEL version: {{rhel_version}}, current RHEL version: {{ansible_distribution_version}} "
+    create: yes
+    state: present
+  when: "ansible_distribution_version != rhel_version"
+
 - name: Check number of users on the machine
   shell: getent passwd {1000..60000} | grep -v {{ admin_user }} | wc -l
   register: users_on_machine


### PR DESCRIPTION
Changes in client package or installation of client package can lead to RHEL version mismatch.
This PR adds the validation by extracting the RHEL version of the image and comparing it with the extracted RHEL version from the ISO URL input in the image build pipeline.

Task: https://msazure.visualstudio.com/One/_workitems/edit/13738014