### PR TITLE
[RHEL 8.1/7.9] Added test case to check new blacklisted modules on rhel 8.1/7.9 images

### DIFF
--- a/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
+++ b/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
@@ -20,15 +20,36 @@
     - amdgpu
   ignore_errors: yes
 
+- name: Check if the drivers are  blacklisted in RHEL 8.1 images
+  shell: modprobe --showconfig | grep blacklist | grep "blacklist {{item}}"
+  register: blacklisted_drivers_specific_rhelversion
+  with_items:
+    - blacklist intel_uncore
+    - blacklist intel_rapl
+    - blacklist acpi_cpufreq
+  ignore_errors: yes
+  when: ansible_distribution_version == "8.1"
+
 - name: Initialize an empty list for storing blacklisted drivers
   set_fact:
     missing_drivers_allimages: []
 
-- name: "Get list of missing drivers to be blacklisted in RHEL images"
+- name: Initialize an empty list for storing blacklisted drivers for specific images
+  set_fact:
+    missing_drivers_specific_rhelversion: []
+
+- name: "Get list of missing drivers to be blacklisted in RHEL 8.1 images"
   set_fact: missing_drivers_allimages="{{ blacklisted_drivers_allimages.results | json_query(jmesquery)}}"
   vars:
     jmesquery: '[?rc==`1`].item'
   when: blacklisted_drivers_allimages is not succeeded
+
+- name: "Get list of missing drivers to be blacklisted in all images"
+  set_fact: missing_drivers_specific_rhelversion="{{ blacklisted_drivers_specific_rhelversion.results | json_query(jmesquery)}}"
+  vars:
+    jmesquery: '[?rc==`1`].item'
+  when: blacklisted_drivers_specific_rhelversion is not succeeded
+
 
 - name: "Write to error msg if some drivers are not blacklisted"
   lineinfile:
@@ -36,7 +57,7 @@
     line: "\nFailed to blacklist the following drivers"
     create: yes
     state: present
-  when: blacklisted_drivers_allimages is not succeeded
+  when: (blacklisted_drivers_allimages is not succeeded) or (blacklisted_drivers_specific_rhelversion is not succeeded)
 
 - name: "Add missing drivers from the blacklist configuration"
   lineinfile:
@@ -44,5 +65,5 @@
     line: "{{item}} is not blacklisted"
     create: yes
     state: present
-  with_items: "{{missing_drivers_allimages}}"
-  when: blacklisted_drivers_allimages is not succeeded
+  with_items: "{{missing_drivers_allimages + missing_drivers_specific_rhelversion}}"
+  when: (blacklisted_drivers_allimages is not succeeded) or (blacklisted_drivers_specific_rhelversion is not succeeded)

--- a/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
+++ b/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
@@ -18,15 +18,15 @@
     - skx_edac
     - intel_cstate
     - amdgpu
+    - intel_uncore
+    - acpi_cpufreq
   ignore_errors: yes
 
 - name: Check if the drivers are  blacklisted in RHEL 8.1 and 7.9 images
   shell: modprobe --showconfig | grep blacklist | grep "blacklist {{item}}"
   register: blacklisted_drivers_specific_rhelversion
   with_items:
-    - blacklist intel_uncore
-    - blacklist intel_rapl
-    - blacklist acpi_cpufreq
+    - intel_rapl
   ignore_errors: yes
   when: ansible_distribution_version == "8.1"  or ansible_distribution_version == "7.9"
 

--- a/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
+++ b/ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml
@@ -20,7 +20,7 @@
     - amdgpu
   ignore_errors: yes
 
-- name: Check if the drivers are  blacklisted in RHEL 8.1 images
+- name: Check if the drivers are  blacklisted in RHEL 8.1 and 7.9 images
   shell: modprobe --showconfig | grep blacklist | grep "blacklist {{item}}"
   register: blacklisted_drivers_specific_rhelversion
   with_items:
@@ -28,7 +28,7 @@
     - blacklist intel_rapl
     - blacklist acpi_cpufreq
   ignore_errors: yes
-  when: ansible_distribution_version == "8.1"
+  when: ansible_distribution_version == "8.1"  or ansible_distribution_version == "7.9"
 
 - name: Initialize an empty list for storing blacklisted drivers
   set_fact:
@@ -38,7 +38,7 @@
   set_fact:
     missing_drivers_specific_rhelversion: []
 
-- name: "Get list of missing drivers to be blacklisted in RHEL 8.1 images"
+- name: "Get list of missing drivers to be blacklisted in RHEL 8.1 and 7.9 images"
   set_fact: missing_drivers_allimages="{{ blacklisted_drivers_allimages.results | json_query(jmesquery)}}"
   vars:
     jmesquery: '[?rc==`1`].item'


### PR DESCRIPTION
Why is it required?
A new bug was found in RHEL 8.1 and 7.9 images due to which provisioning via cloud-init was failing on the VM SKU 'Standard_M832ixs_v2'.

REF:
https://msazure.visualstudio.com/One/_workitems/edit/15616372

Changes:
1. ansible_image_validation/validation-playbooks/blacklisted_drivers_validation.yaml :  Added a new list of drivers to be tested only on RHEL 8.1 and 7.9 images build via our image build pipeline

succesful validation in pipeline: [https://msazure.visualstudio.com/One/_build/results?buildId=60838373&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=75d7c487-a25f-5c93-4fef-a52cd687e810](https://msazure.visualstudio.com/One/_build/results?buildId=60838373&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=75d7c487-a25f-5c93-4fef-a52cd687e810)