### PR TITLE
Run ADE package validation for RHEL7/8 only

### DIFF
--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -53,7 +53,7 @@
 - name: check if ADE validation is valid for this vm
   include_tasks: validation-playbooks/ade_packages_validation.yaml
   ignore_errors: yes
-  when: ansible_os_family == "RedHat" and (repo_type == 'base' or repo_type =='beta')
+  when: ansible_os_family == "RedHat" and (ansible_distribution_major_version == '8' or ansible_distribution_major_version == '7') and (repo_type == 'base' or repo_type =='beta')
 
 - name: Check if blacklisted drivers are blacklisted by modprobe service
   include_tasks: validation-playbooks/blacklisted_drivers_validation.yaml


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?
As per ADE document https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-overview#supported-vms-and-operating-systems, only RHEL7 and RHEL8 are currently supported.
We are hence, removing the validation for RHEL9 as it is failing the pipeline builds. 

## What changes have been made?
Include ADE validation task only for RHEL7 and RHEL8 VMs

## References:
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-isolated-network
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-overview#supported-vms-and-operating-systems

