### PR TITLE
[CVM 9.3 beta] Disable nvme Test cases for cvm images

### DIFF
--- a/ansible_image_validation/validate-vm-images.yaml
+++ b/ansible_image_validation/validate-vm-images.yaml
@@ -19,6 +19,7 @@
           - "offer_type is defined"
           - "rhel_version is defined"
           - "build_on_rhui4 is defined"
+          - "isCVM is defined"
 
     - set_fact:
         rhui3_regions: "{{ lookup('file', 'files/rhui3-regions').split() }}"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -60,35 +60,51 @@
   ignore_errors: yes
   when: ansible_os_family == "RedHat"
 
-- name: Check if the nvme driver is present in all images
-  shell: lsinitrd /boot/initramfs-{{ ansible_facts.kernel }}.img | grep nvme
-  register: check_nvme_allimages
+- name: Check if the initramfs file is present
+  stat: path=/boot/initramfs-{{ ansible_facts.kernel }}.img
+  register: initramfs_present
+  when: isCVM is false
 
-- debug:
-    var: check_nvme_allimages
-
-- name: "Write to error msg if some drivers are not present"
+- name: "Write to error msg if initramfs files are not present"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n NVME validation failed since nvme driver is not present. "
+    line: "\n boot validation failed since initramfs file is not present."
     create: yes
     state: present 
-  when: ("nvme" not in check_nvme_allimages.stdout)
+  when: isCVM is false and initramfs_present.stat.exists == false
 
-- name: Check if the pci driver is present in all images
-  shell: lsinitrd /boot/initramfs-{{ ansible_facts.kernel }}.img | grep pci
-  register: check_pci_allimages
+- name: Check for NVME/PCI Drivers in image
+  when: isCVM is false and initramfs_present.stat.exists == true
+  block:
+  - name: Check if the nvme driver is present in all images
+    shell: lsinitrd /boot/initramfs-{{ ansible_facts.kernel }}.img | grep nvme
+    register: check_nvme_allimages
 
-- debug:
-    var: check_pci_allimages
+  - debug:
+      var: check_nvme_allimages
 
-- name: "Write to error msg if some drivers are not present"
-  lineinfile:
-    path: "{{err_folder}}/err_msgs.log"
-    line: "\n NVME validation failed since pci driver is not present. "
-    create: yes
-    state: present 
-  when: ("pci" not in check_pci_allimages.stdout)
+  - name: "Write to error msg if some drivers are not present"
+    lineinfile:
+      path: "{{err_folder}}/err_msgs.log"
+      line: "\n NVME validation failed since nvme driver is not present. "
+      create: yes
+      state: present 
+    when: ("nvme" not in check_nvme_allimages.stdout)
+
+  - name: Check if the pci driver is present in all images
+    shell: lsinitrd /boot/initramfs-{{ ansible_facts.kernel }}.img | grep pci
+    register: check_pci_allimages
+
+  - debug:
+      var: check_pci_allimages
+
+  - name: "Write to error msg if some drivers are not present"
+    lineinfile:
+      path: "{{err_folder}}/err_msgs.log"
+      line: "\n NVME validation failed since pci driver is not present. "
+      create: yes
+      state: present 
+    when: ("pci" not in check_pci_allimages.stdout)
 
 - name: Check for Rhui client package in the image
   when: license_type != 'byos'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?
RHEL 9.3 CVM is required to be built and published as a public preview feature on Azure from November.
RHEL 9.3 Beta CVM image for Sev-SNP has been built with the changes introduced in the PR https://msazure.visualstudio.com/One/_git/Compute-AzLinux-RedHat-Image/pullrequest/8910396 

However, the validation pipeline was failing due to NVME testcase that check for initramfs files in the boot directory. Since the CVM Images have unified kernel and doesn't have initramfs, the testcase needs to be skipped for the CVM images.

## What changes have been made?

1. Added check to check for the initramfs file first.
2. Added check for CVM images and skip NVME testcases for these images

## Successful Pipeline Link (optional):
Link to the successful pipeline [run ](https://msazure.visualstudio.com/One/_build/results?buildId=81369616&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=74c1e0dc-9a34-5729-63ae-cbe4812f6ec1)
