### PR TITLE
Added Scripts to check the presence of unmanaged devices in Rhel 9 Images.

### DIFF
--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -142,16 +142,16 @@
     when: rhui_package_count != "0"
 
 
-- name: Check for the Accelerated Networking in Rhel 9 Images.
-  when: isCVM is false and ansible_distribution_major_version == '9'
-  block:
-  - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
-    shell: NetworkManager --print-config
-    register: check_network_config
-
+  - name: Check for the Accelerated Networking in Rhel 9 Images.
+    when: isCVM is false and ansible_distribution_major_version == '9'
+    block:
+    - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
+      shell: NetworkManager --print-config
+      register: check_network_config
+  
   - debug:
       var: check_network_config
-
+  
   - name: "Write to error msg if t"
     lineinfile:
       path: "{{err_folder}}/err_msgs.log"
@@ -159,19 +159,20 @@
       create: yes
       state: present 
     when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
-
-
+  
+  
   - name: Check if the accelerated networking config file is present in all Rhel 9 Images
-    shell: cat /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+    stat:
+      path: /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
     register: check_99_azure_unmanaged_devices_config_file
-
+  
   - debug:
       var: check_99_azure_unmanaged_devices_config_file
-
-  - name: "Write to error msg if some drivers are not present"
+  
+  
+  - name: "Write to error msg if the file is not present"
     lineinfile:
-      path: "{{err_folder}}/err_msgs.log"
+      path: "./err_msgs.log"
       line: "\n Validation failed since unmanaged config file is not present. "
-      create: yes
-      state: present 
-    when: ("driver:mlx4_core;driver:mlx5_core" not in check_99_azure_unmanaged_devices_config_file.stdout)    
+    when: not check_99_azure_unmanaged_devices_config_file.stat.exists    
+  

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -141,38 +141,35 @@
       is_rhui_package_present : true
     when: rhui_package_count != "0"
 
-
-  - name: Check for the Accelerated Networking in Rhel 9 Images.
-    when: isCVM is false and ansible_distribution_major_version == '9'
-    block:
+- name: Check for the Accelerated Networking in Rhel 9 Images.
+  when: isCVM is false and ansible_distribution_major_version == '9'
+  block:
     - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
       shell: NetworkManager --print-config
       register: check_network_config
   
-  - debug:
-      var: check_network_config
-  
-  - name: "Write to error msg if t"
-    lineinfile:
-      path: "{{err_folder}}/err_msgs.log"
-      line: "\n Accelerated Networking Validation failed."
-      create: yes
-      state: present 
-    when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
-  
-  
-  - name: Check if the accelerated networking config file is present in all Rhel 9 Images
-    stat:
-      path: /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
-    register: check_99_azure_unmanaged_devices_config_file
-  
-  - debug:
-      var: check_99_azure_unmanaged_devices_config_file
-  
-  
-  - name: "Write to error msg if the file is not present"
-    lineinfile:
-      path: "./err_msgs.log"
-      line: "\n Validation failed since unmanaged config file is not present. "
-    when: not check_99_azure_unmanaged_devices_config_file.stat.exists    
-  
+    - debug:
+        var: check_network_config
+    
+    - name: "Write to error msg if unmanaged drivers are not present"
+      lineinfile:
+        path: "{{err_folder}}/err_msgs.log"
+        line: "\n Accelerated Networking Validation failed since unmanaged drivers are not present."
+        create: yes
+        state: present 
+      when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
+    
+    - name: Check if the accelerated networking config file is present in all Rhel 9 Images
+      stat:
+        path: /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+      register: check_99_azure_unmanaged_devices_config_file
+    
+    - debug:
+        var: check_99_azure_unmanaged_devices_config_file
+    
+    - name: "Write to error msg if the file is not present"
+      lineinfile:
+        path: "./err_msgs.log"
+        line: "\n Accelerated Networking Validation failed since unmanaged config file is not present. "
+      when: not check_99_azure_unmanaged_devices_config_file.stat.exists    
+    

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -158,7 +158,7 @@
       line: "\n Accelerated Networking Validation failed . "
       create: yes
       state: present 
-    when: ("nvme" not in check_network_config.stdout)    
+    when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout)    
 
 
   - name: Check if the unmanaged devices config file is present in all Rhel 9 Images
@@ -174,4 +174,4 @@
       line: "\n Validation failed since unmanaged config file is not present. "
       create: yes
       state: present 
-    when: ("nvme" not in check_99_azure_unmanaged_devices_config_file.stdout)    
+    when: ("driver:mlx4_core;driver:mlx5_core" not in check_99_azure_unmanaged_devices_config_file.stdout)    

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -143,7 +143,7 @@
 
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.
-  when: isCVM is false and 
+  when: isCVM is false and ansible_distribution_major_version == '9'
   block:
   - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
     shell: NetworkManager --print-config
@@ -155,13 +155,13 @@
   - name: "Write to error msg if t"
     lineinfile:
       path: "{{err_folder}}/err_msgs.log"
-      line: "\n Accelerated Networking Validation failed . "
+      line: "\n Accelerated Networking Validation failed."
       create: yes
       state: present 
     when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout)    
 
 
-  - name: Check if the unmanaged devices config file is present in all Rhel 9 Images
+  - name: Check if the accelerated networking config file is present in all Rhel 9 Images
     shell: cat /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
     register: check_99_azure_unmanaged_devices_config_file
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -158,7 +158,7 @@
       line: "\n Accelerated Networking Validation failed."
       create: yes
       state: present 
-    when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout)    
+    when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
 
 
   - name: Check if the accelerated networking config file is present in all Rhel 9 Images

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -140,3 +140,38 @@
     set_fact:
       is_rhui_package_present : true
     when: rhui_package_count != "0"
+
+
+- name: Check for the Accelerated Networking in Rhel 9 Images.
+  when: isCVM is false and 
+  block:
+  - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
+    shell: NetworkManager --print-config
+    register: check_network_config
+
+  - debug:
+      var: check_network_config
+
+  - name: "Write to error msg if t"
+    lineinfile:
+      path: "{{err_folder}}/err_msgs.log"
+      line: "\n Accelerated Networking Validation failed . "
+      create: yes
+      state: present 
+    when: ("nvme" not in check_network_config.stdout)    
+
+
+  - name: Check if the unmanaged devices config file is present in all Rhel 9 Images
+    shell: cat /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+    register: check_99_azure_unmanaged_devices_config_file
+
+  - debug:
+      var: check_99_azure_unmanaged_devices_config_file
+
+  - name: "Write to error msg if some drivers are not present"
+    lineinfile:
+      path: "{{err_folder}}/err_msgs.log"
+      line: "\n Validation failed since unmanaged config file is not present. "
+      create: yes
+      state: present 
+    when: ("nvme" not in check_99_azure_unmanaged_devices_config_file.stdout)    


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?
This PR is required to check the presence of unmanaged devices in Rhel 9 Images.


## What changes have been made?
Added ansible tasks in ansible_image_validation\validation-playbooks\per-vm-validation.yaml file.

## Successful Pipeline Link (optional):
Link to the successful pipeline run (if any):
- https://msazure.visualstudio.com/One/_build/results?buildId=87285738&view=results
- https://msazure.visualstudio.com/One/_build/results?buildId=87295099&view=results

Test Case where Pipeline is failing: 
- https://msazure.visualstudio.com/One/_build/results?buildId=87647895&view=results
![image](https://github.com/Azure/linux-image-validations/assets/112065840/5a2c0e79-8362-4c8c-bbf0-47ce0b7c0fc4)

## Results after running the playbook:

- Test results after running the playbook when unmanaged drivers are not present:

![image](https://github.com/Azure/linux-image-validations/assets/112065840/1185b7b8-2751-40d6-8e75-815d7d0c7d39)


![image](https://github.com/Azure/linux-image-validations/assets/112065840/f442d578-7da0-47a7-a46c-668cad11bb7f)


![image](https://github.com/Azure/linux-image-validations/assets/112065840/46d157fe-1b5c-49d5-87e0-c3c636d22467)


- Test results after running the playbook when unmanaged drivers are present:

![image](https://github.com/Azure/linux-image-validations/assets/112065840/ac6afdf1-3174-485c-aaad-654222db0bfc)


![image](https://github.com/Azure/linux-image-validations/assets/112065840/a5a548be-6bed-4463-a18f-dbb6b6758508)


![image](https://github.com/Azure/linux-image-validations/assets/112065840/dea365cd-9164-445e-a752-aa3306cf546f)


- Test results in 8.6 RHEL Image:

![image](https://github.com/Azure/linux-image-validations/assets/112065840/b484095f-14e2-41ff-9a36-0c4bfab2f370)



-  Test results in 9.3 RHEL Image:

![image](https://github.com/Azure/linux-image-validations/assets/112065840/ed2be04a-dec2-45d1-874c-b90f388f7336)

