### PR TITLE
Add validation tasks to check the correctness of the offertype and client package

### DIFF
--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -146,7 +146,7 @@
 - name: Check if offertype is equal to byol and client package is present
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n  Client Package {{ rhui_package }} is present in BYOL Offertype Image"
+    line: "\n  Client Package is present in BYOL Offertype Image. Details of the client package {{ rhui_package }}"
     create: yes
     state: present 
   when: offer_type =='byol' and rhui_package_count != "0"
@@ -162,6 +162,7 @@
               substring="arm64"
               clientpkgwithoutarchitecture="${client_package//$substring/}"
               client_package=clientpkgwithoutarchitecture
+              echo $client_package
           fi
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,20 +159,18 @@
 - debug:
     var: output_client_package
 
-## Logic: Example client package for x86-64 based architecture: rhui-azure-rhel9-eus-2.3-655.noarch. This client package contains eus based offertype. 
-## For BYOL offertype, this task is getting skippied.
-## According to the below logic, if the offertype value present inside the client package naming is different from the offertype value which is being supplied through the pipeline variables, then incorrect client package is present inside the RHEL Image according to the given offertype.
-## For base offertype, client package naming should not contain any offertype value. The below logic is iterating through the list of all the existing offertypes and checks if the value of any offertype is also present in the client package naming.
-## For the offers other than base and byol, the logic is iterating from the index 17 which means that it is skipping "rhui-azure-rhel9-"" portion of client package naming and only extracts the offertype whcih is present in the client package naming itself and stores it in a variable offer_within_clientpkg.
-## offer_within_clientpkg is equated against the {{ offer_type }} variable which is being supplied through the pipeline variables. If the correct client package is present, then the value of offer_within_clientpkg should be equal to the {{ offer_type }} variable.
-
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if [[ "{{ architecture }}" -ne "arm64" ]]; then
-              client_package={{ output_client_package.stdout_lines[0] }}   ##debug
+           client_package={{ output_client_package.stdout_lines[0] }} 
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then
+              clientpkgwithoutarchitecture=""
+              substring="arm64"
+              clientpkgwithoutarchitecture="${client_package//$substring/}"
+              client_package=clientpkgwithoutarchitecture
+          fi
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"
               string_without_substring="${client_package//$substring/}"
@@ -187,10 +185,7 @@
                     echo "Correct Client Package according to the given offertype"
               else
                     echo "Incorrect Client Package according to the given offertype"
-              fi    
-           else 
-               echo "debugging"
-           fi     
+              fi       
   register: output_offertype_except_byol
   when: offer_type !='byol' 
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -171,7 +171,7 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if ( "{{ architecture }}" != "arm64"); then
+          if ( "{{ architecture }}" -ne "arm64"); then
               client_package={{ output_client_package.stdout_lines[0] }}   ##debug
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"
@@ -188,7 +188,6 @@
               else
                     echo "Incorrect Client Package according to the given offertype"
               fi    
-
            else 
                echo "debugging"
            fi     

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -174,6 +174,8 @@
   register: output_offertype_except_byol
   when: offer_type !='byol'                       
 
+- debug:
+    var: output_offertype_except_byol 
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol.
   ansible.builtin.shell:

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -146,25 +146,16 @@
 - name: Check if offertype is equal to byol and client package is present
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n  Client Package is present in byol Offertype Image"
+    line: "\n  Client Package {{ rhui_package }} is present in BYOL Offertype Image"
     create: yes
     state: present 
   when: offer_type =='byol' and rhui_package_count != "0"
-
-- name: Check the value of client package
-  shell: rpm -qa | grep rhui
-  register: output_client_package
-  when: offer_type!='byol'
-
-- debug:
-    var: output_client_package
-
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          client_package={{ output_client_package.stdout_lines[0] }} 
+          client_package=$(rpm-qa | grep rhui) 
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               echo "statement 1"
               clientpkgwithoutarchitecture=""

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,7 +159,7 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               clientpkgwithoutarchitecture=""
               substring="arm64"
-              clientpkgwithoutarchitecture="${client_package//$substring/}"
+              clientpkgwithoutarchitecture = "${client_package//$substring/}"
               echo $clientpkgwithoutarchitecture
               client_package=clientpkgwithoutarchitecture
           fi

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -192,7 +192,7 @@
             echo  {{ offer_type }} 
             offervalue={{ offer_type }}
             offervalue=${offervalue//-/}
-            offer_within_clientpkg=${$offer_within_clientpkg//-/}
+            offer_within_clientpkg=${offer_within_clientpkg//-/}
             if [[ $offervalue == $offer_within_clientpkg ]]; then 
                   echo "Correct Client Package according to the given offertype"
             else

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -168,9 +168,9 @@
 
 ## Logic: Example client package for x86-64 based architecture: rhui-azure-rhel9-eus-2.3-655.noarch. This client package contains eus based offertype. 
 ## For BYOL offertype, this task is getting skippied.
-## According to the below logic, if the offertype value present inside the client package is different from the offertype value which is being supplied through the pipeline variables,It indicates that incorrect client package is present inside the RHEL Image according to the given offertype.
-## For base offertype, client package naming should not contain any offertype value. The below logic is iterating through the list of all the offertypes and checks if the value of any offertype is also present in the client package naming.
-## For the offers other than base and byol, the logic is iterating from the index 17 which means that it is skipping "rhui-azure-rhel9-"" portion of client package naming and only extracts the offertype whcih is present in the client package naming itself and storing it in a variable offer_within_clientpkg.
+## According to the below logic, if the offertype value present inside the client package naming is different from the offertype value which is being supplied through the pipeline variables, then incorrect client package is present inside the RHEL Image according to the given offertype.
+## For base offertype, client package naming should not contain any offertype value. The below logic is iterating through the list of all the existing offertypes and checks if the value of any offertype is also present in the client package naming.
+## For the offers other than base and byol, the logic is iterating from the index 17 which means that it is skipping "rhui-azure-rhel9-"" portion of client package naming and only extracts the offertype whcih is present in the client package naming itself and stores it in a variable offer_within_clientpkg.
 ## offer_within_clientpkg is equated against the {{ offer_type }} variable which is being supplied through the pipeline variables. If the correct client package is present, then the value of offer_within_clientpkg should be equal to the {{ offer_type }} variable.
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
@@ -227,6 +227,13 @@
     state: present 
   when: ( offer_type!='byol') and ( architecture == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
+## Logic: Example client package for arm64 based architecture: rhui-azure-rhel9-eus-arm64-2.3-655.noarch. This client package contains eus based offertype. 
+## For base offertype, the client package is rhui-azure-rhel9-arm64-2.3-655.noarch.
+## The difference between the naming of x86-64 based client pkgs and arm64 based client pkgs is that arm64 based client pkgs contain the name of architecture tyoe also. This has been taken into account in the below implemented logic.
+## For BYOL offertype, this task is getting skippied.
+## According to the below logic, the value of client package is iterated from index 17 and iteration runs until it gets a number and the substring is stored inside the variable offer_within_clientpkg. The substring will contain offertype value + "arm".
+## For base offertype, the value of substring should be equal to arm. For eus offertype, the value of substring should be eus-arm. The below implemented logic is equating these conditions and validates if the exisiting client pkg is according to the given offertype.
+## For arm64 based architecture type, we only published base and eus offertype images Therefore, other offertypes are not taken into an account in the below validation task. 
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to arm64.
   ansible.builtin.shell:

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -163,7 +163,7 @@
               client_package=$clientpkgwithoutarchitecture                            
           fi                                                                            
               substring="${client_package:0:17}"                                       ## The substring "rhui-azure-rhel9-" will be eliminated from the variable which contains the value of client package.
-              client_pkg_without_substring="${client_package//$substring/}"                ## After removing the above substring, the remaining string will be eus-2.3-655.noarch. For base client packages, it should be only 2.3-655.noarch. This value is getting stored in string_without_substring variable.
+              client_pkg_without_substring="${client_package//$substring/}"            ## After removing the above substring, the remaining string will be equal to "offer"+"build numer"+ noarch value. Example string: eus-2.3-655.noarch. For base client packages, it should be only 2.3-655.noarch. This value is getting stored in string_without_substring variable.
               echo $client_pkg_without_substring
               offerval="${client_pkg_without_substring%%[0-9]*}"                           ## The value of the offertype which is present in the name of client package is getting calculated from string_without_substring variable. It will be equal to eus-, sap-apps-, sap-ha- etc values. For base offertypes, it will be equal to - .This value is getting stored in offerval variable.
               echo $offerval       
@@ -174,13 +174,16 @@
               echo "Print the value of the offertype passed in the pipeline variables: " $offertype
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_image
               offer_within_clientpkg=${offer_within_clientpkg//-/}
+
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$offer_in_rhel_image" ]]; then 
+                        echo "block 1"
                         echo "Correct Client Package according to the given offertype"
                   else
                         echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of offer_in_rhel_image variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
               else    
+                  echo "block 2"
                   if [[ $offer_type == $offer_in_rhel_image ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -175,10 +175,13 @@
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"
               string_without_substring="${client_package//$substring/}"
+              echo $string_without_substring
               offerval="${string_without_substring%%[0-9]*}"          
               offer_in_rhel_image=${offerval//-/}
               offertype={{ offer_type }}
               offertype=${offertype//-/}
+              echo $offertype
+              echo $offer_in_rhel
               echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
               offer_within_clientpkg=${offer_within_clientpkg//-/}

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -232,6 +232,8 @@
                 if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
                       break;
                 else
+                      echo "Debug statement"
+                      echo "${client_package:i:1}"
                       offer_within_clientpkg="${offer_within_clientpkg}${client_package:i:1}"
                 fi  
             done 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -143,6 +143,14 @@
 
 ##Repo Validation Task
 
+- name: Check if more than 1 client package is present in the RHEL Image
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n  The RHEL Image contains more than 1 client package"
+    create: yes
+    state: present 
+  when: rhui_package_count > "1"
+
 - name: Check if offertype is equal to byol and client package is present
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
@@ -150,7 +158,6 @@
     create: yes
     state: present 
   when: offer_type =='byol' and rhui_package_count != "0"
-
 
 - name: Check if the client package is present according to correct architecture
   ansible.builtin.shell:

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,13 +159,6 @@
 - debug:
     var: output_client_package
 
-- name: Check the architecture of the RHEL Image.
-  shell: echo {{ architecture }}
-  register: output_architecture
-
-- debug:
-    var: output_architecture
-
 ## Logic: Example client package for x86-64 based architecture: rhui-azure-rhel9-eus-2.3-655.noarch. This client package contains eus based offertype. 
 ## For BYOL offertype, this task is getting skippied.
 ## According to the below logic, if the offertype value present inside the client package naming is different from the offertype value which is being supplied through the pipeline variables, then incorrect client package is present inside the RHEL Image according to the given offertype.
@@ -173,48 +166,32 @@
 ## For the offers other than base and byol, the logic is iterating from the index 17 which means that it is skipping "rhui-azure-rhel9-"" portion of client package naming and only extracts the offertype whcih is present in the client package naming itself and stores it in a variable offer_within_clientpkg.
 ## offer_within_clientpkg is equated against the {{ offer_type }} variable which is being supplied through the pipeline variables. If the correct client package is present, then the value of offer_within_clientpkg should be equal to the {{ offer_type }} variable.
 
+
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-      client_package={{ output_client_package.stdout_lines[0] }}
-      if [[ {{ offer_type }} == "base" ]]; then 
-          repotypes=("beta" "base" "eus" "sap-ha" "base-sap-ha" "byol" "sap-apps" "base-sap-apps" "ha")
-          for repo in ${repotypes[@]};
-            do
-              echo $repo
-              z=$(echo $client_package | grep $repo)
-              if [[ -n $z ]]; then
-                echo "Incorrect Client Package according to the given offertype"
-              else  
-                echo "Correct Client Package according to the given offertype"
-              fi
-          done       
-      else  
-          offer_within_clientpkg=""
-          len="$(echo -n "$client_package" | wc -c)"
-          for (( i=17; i<len; i++  ));
-            do
-              if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
-                    break;
+          if ( {{ architecture != "arm64"}}); then
+              client_package={{ output_client_package.stdout_lines[0] }} 
+              offer_in_rhel_image=""
+              substring="rhui-azure-rhel9-"
+              string_without_substring="${client_package//$substring/}"
+              offerval="${string_without_substring%%[0-9]*}"          
+              offer_in_rhel_image=${offerval//-/}
+              echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
+              echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
+              offer_within_clientpkg=${offer_within_clientpkg//-/}
+              if [[ {{ offer_type }}  == $offer_in_rhel_imag ]]; then 
+                    echo "Correct Client Package according to the given offertype"
               else
-                    offer_within_clientpkg="${offer_within_clientpkg}${client_package:i:1}"
-              fi  
-          done 
-            offer_within_clientpkg="${offer_within_clientpkg%?}"
-            echo $offer_within_clientpkg   
-            echo  {{ offer_type }} 
-            offervalue={{ offer_type }}
-            offervalue=${offervalue//-/}
-            offer_within_clientpkg=${offer_within_clientpkg//-/}
-            if [[ $offervalue == $offer_within_clientpkg ]]; then 
-                  echo "Correct Client Package according to the given offertype"
-            else
-                  echo "Incorrect Client Package according to the given offertype"
-            fi    
-      fi    
+                    echo "Incorrect Client Package according to the given offertype"
+              fi    
+
+           else 
+               echo "debugging"
+           fi     
   register: output_offertype_except_byol
-  when: offer_type !='byol' and  architecture == "x86-64"
+  when: offer_type !='byol' 
 
 - debug:
     var: output_offertype_except_byol 
@@ -225,60 +202,8 @@
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ( architecture == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
+  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
-## Logic: Example client package for arm64 based architecture: rhui-azure-rhel9-eus-arm64-2.3-655.noarch. This client package contains eus based offertype. 
-## For base offertype, the client package is rhui-azure-rhel9-arm64-2.3-655.noarch.
-## The difference between the naming of x86-64 based client pkgs and arm64 based client pkgs is that arm64 based client pkgs contain the name of architecture tyoe also. This has been taken into account in the below implemented logic.
-## For BYOL offertype, this task is getting skippied.
-## According to the below logic, the value of client package is iterated from index 17 and iteration runs until it gets a number and the substring is stored inside the variable offer_within_clientpkg. The substring will contain offertype value + "arm".
-## For base offertype, the value of substring should be equal to arm. For eus offertype, the value of substring should be eus-arm. The below implemented logic is equating these conditions and validates if the exisiting client pkg is according to the given offertype.
-## For arm64 based architecture type, we only published base and eus offertype images Therefore, other offertypes are not taken into an account in the below validation task. 
-
-- name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to arm64.
-  ansible.builtin.shell:
-    cmd: |
-      #!/bin/bash
-            offer_within_clientpkg=""
-            client_package={{ output_client_package.stdout_lines[0] }}
-            len="$(echo -n "$client_package" | wc -c)"
-            for (( i=17; i<len; i++  ));
-              do
-                if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
-                      break;
-                else
-                      offer_within_clientpkg="${offer_within_clientpkg}${client_package:i:1}"
-                fi  
-            done 
-              echo  {{ offer_type }} 
-              echo $offer_within_clientpkg         
-              if [[ {{ offer_type }} == "base" ]]; then         
-                    if [[ $offer_within_clientpkg == "arm" ]]; then
-                        echo "Correct Client Package according to the given offertype"
-                    else
-                        echo "Incorrect Client Package according to the given offertype"
-                    fi
-              else
-                    if [[ $offer_within_clientpkg == "eus-arm" ]]; then
-                        echo "Correct Client Package according to the given offertype"
-                    else
-                        echo "Incorrect Client Package according to the given offertype"
-                    fi
-              fi   
-
-  register: output_offertype_except_byol_arm64
-  when: offer_type !='byol' and  architecture == "arm64"
-
-- debug:
-    var: output_offertype_except_byol_arm64 
-
-- name: "Write to error msg if incorrect client package is present according to the offertype and architecture is equal to arm64"
-  lineinfile:
-    path: "{{err_folder}}/err_msgs.log"
-    line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
-    create: yes
-    state: present 
-  when: ( offer_type!='byol') and ( architecture == "arm64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol_arm64.stdout_lines)  
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.
   when: isCVM is false and ansible_distribution_major_version == '9'

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,7 +159,7 @@
 - debug:
     var: output_client_package
 
-- name: Check the value of architecture
+- name: Check the architecture of the RHEL Image.
   shell: echo {{ architecture }}
   register: output_architecture
 
@@ -207,7 +207,7 @@
             fi    
       fi    
   register: output_offertype_except_byol
-  when: offer_type !='byol' 
+  when: offer_type !='byol' and {{ architecture }} == "x86-64"
 
 - debug:
     var: output_offertype_except_byol 
@@ -218,7 +218,7 @@
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
+  when: ( offer_type!='byol') and ( {{ architecture }} == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -207,7 +207,7 @@
             fi    
       fi    
   register: output_offertype_except_byol
-  when: offer_type !='byol' and {{ architecture }} == "x86-64"
+  when: offer_type !='byol' and  architecture == "x86-64"
 
 - debug:
     var: output_offertype_except_byol 
@@ -218,7 +218,7 @@
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ( {{ architecture }} == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
+  when: ( offer_type!='byol') and ( architecture == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -166,16 +166,16 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Incorrect Client Package according to the given architecture type."
+                      echo "Client Package does not contain the value of arm64 architecture type."
                 else
-                      echo "Client Package according to the given architecture type."                
+                      echo "Client Package contains the value of arm64 architecture type."                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Correct Client Package according to the given architecture type."
+                      echo "Correct Client Package is correct. It does not contain the value of arm64 architecture type"
                 else
-                      echo "Incorrect Client Package according to the given architecture type."               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                      echo "Client Package according to the given architecture type. It contains the value of arm64 architecture type"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
                 fi 
           fi                            
   register: output_offertype_except_byol
@@ -196,8 +196,8 @@
           fi                            
                                                           
                       
-              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Extract suffix  "-2.3-5343.noarch.rpm"  from client package
-              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix  "rhui-azure-rhel8-""  val from client package
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Eliminate the suffix  "-2.3-5343.noarch.rpm"  from client package. Remaining value should be equal to "rhui-azure-rhel8" + "offertype" | Examples: "rhui-azure-rhel8", "rhui-azure-rhel8-eus", "rhui-azure-rhel8-sap-ha"
+              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix rhui-azure-rhel8"  value from client package
               extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                   ## For Base Offertype, extract_offer_val should be equal to null.
 
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -228,6 +228,8 @@
             offer_within_clientpkg=""
             len="$(echo -n "$client_package" | wc -c)"
             for (( i=17; i<len; i++  ));
+                echo "Debug statement"
+                echo "${client_package:i:1}
               do
                 if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
                       break;

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -107,7 +107,6 @@
     when: ("pci" not in check_pci_allimages.stdout)
 
 - name: Check for Rhui client package in the image
-  when: license_type != 'byos'
   block:
   - name: Gather the package facts
     ansible.builtin.package_facts:

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -140,7 +140,7 @@
       is_rhui_package_present : true
     when: rhui_package_count != "0"
 
-- name: Check the repo-validation
+- name: Check the repo-validation of RHEL Image according to the offertype and client package present in it.
   include_tasks: validation-playbooks/repo-validation-check.yaml
   ignore_errors: yes
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -155,38 +155,36 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          client_package=$( rpm -qa | grep rhui ) 
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then
-              substring="arm64-"
-              clientpkgwithoutarchitecture="${client_package//$substring/}"
+          client_package=$( rpm -qa | grep rhui )                                      ## Value of client package is getting calculated
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                              ## if the architecture is arm64 based then client package value will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
+              substring="arm64-"                                                       ## The value of client packages for architecture type x86-64 don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+              clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
               echo $clientpkgwithoutarchitecture
-              client_package=$clientpkgwithoutarchitecture
-          fi
-              offer_in_rhel_image=""
-              substring="rhui-azure-rhel9-"
-              string_without_substring="${client_package//$substring/}"
-              echo $string_without_substring
-              offerval="${string_without_substring%%[0-9]*}"   
+              client_package=$clientpkgwithoutarchitecture                            
+          fi                                                                            
+              substring="${client_package:0:17}"                                       ## The substring "rhui-azure-rhel9-" will be eliminated from the variable which contains the value of client package.
+              client_pkg_without_substring="${client_package//$substring/}"                ## After removing the above substring, the remaining string will be eus-2.3-655.noarch. For base client packages, it should be only 2.3-655.noarch. This value is getting stored in string_without_substring variable.
+              echo $client_pkg_without_substring
+              offerval="${client_pkg_without_substring%%[0-9]*}"                           ## The value of the offertype which is present in the name of client package is getting calculated from string_without_substring variable. It will be equal to eus-, sap-apps-, sap-ha- etc values. For base offertypes, it will be equal to - .This value is getting stored in offerval variable.
               echo $offerval       
-              offer_in_rhel_image=${offerval//-/}
+              offer_in_rhel_image=${offerval//-/}                                      ## In this command, all the hyphens are being removed from the above substring. This is important because the value of sap-apps client package is rhui-azure-rhel8-sapapps-2.3-5272.noarch. Hyphen needs to be removed to equate the offertype values. Client Package Pipeline Build Run: https://msazure.visualstudio.com/One/_build/results?buildId=93555256&view=artifacts&pathAsName=false&type=publishedArtifacts
               offertype={{ offer_type }}
-              offertype=${offertype//-/}
-              echo $offertype
-              echo $offer_in_rhel
-              echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
-              echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
+              offertype=${offertype//-/}                                               ## In this command, all the hyphens are being removed from the {{ offer_type }} variable which is being supplied through the pipeline and the output is stored in the offertype variable.
+
+              echo "Print the value of the offertype passed in the pipeline variables: " $offertype
+              echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_image
               offer_within_clientpkg=${offer_within_clientpkg//-/}
-              if [[ {{ offer_type }} == "base" ]]; then
-                  if [[ -z "$offer_in_rhel_imag" ]]; then 
+              if [[  $offertype  == "base" ]]; then
+                  if [[ -z "$offer_in_rhel_image" ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
-                        echo "Incorrect Client Package according to the given offertype"
+                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of offer_in_rhel_image variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
               else    
-                  if [[ {{ offer_type }}  == $offer_in_rhel_imag ]]; then 
+                  if [[ $offer_type == $offer_in_rhel_image ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
-                        echo "Incorrect Client Package according to the given offertype"
+                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of offer_in_rhel_image variable should not be null.
                   fi   
               fi
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -188,9 +188,12 @@
               fi  
           done 
             offer_within_clientpkg="${offer_within_clientpkg%?}"
-            echo $offer_within_clientpkg    
+            echo $offer_within_clientpkg   
             echo  {{ offer_type }} 
-            if [[ {{ offer_type }} == $offer_within_clientpkg ]]; then 
+            offervalue={{ offer_type }}
+            offervalue=${offervalue//-/}
+            offer_within_clientpkg=${$offer_within_clientpkg//-/}
+            if [[ $offervalue == $offer_within_clientpkg ]]; then 
                   echo "Correct Client Package according to the given offertype"
             else
                   echo "Incorrect Client Package according to the given offertype"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -171,8 +171,8 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if ( {{ architecture }} != "arm64"); then
-              client_package={{ output_client_package.stdout_lines[0] }} 
+          if ( "{{ architecture }}" != "arm64"); then
+              client_package={{ output_client_package.stdout_lines[0] }}   ##debug
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"
               string_without_substring="${client_package//$substring/}"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -197,7 +197,9 @@
                                                           
                       
               package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Extract suffix  "-2.3-5343.noarch.rpm"  from client package
-              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')                                    ## Extract prefix  "rhui-azure-rhel8-""  val from client package
+              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix  "rhui-azure-rhel8-""  val from client package
+              extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                   ## For Base Offertype, extract_offer_val should be equal to null.
+
 
               offertype={{ offer_type }}
               offertype=${offertype//-/}  

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -228,8 +228,8 @@
             offer_within_clientpkg=""
             len="$(echo -n "$client_package" | wc -c)"
             for (( i=17; i<len; i++  ));
-                echo "Debug statement"
-                echo "${client_package:i:1}
+                 echo "Debug statement"
+                 echo "${client_package:i:1}"
               do
                 if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
                       break;

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -166,16 +166,16 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Incorrect Client Package according to the given offertype"
+                      echo "Incorrect Client Package according to the given architecture type."
                 else
-                      echo "Client Package according to the given offertype"                
+                      echo "Client Package according to the given architecture type."                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Correct Client Package according to the given offertype"
+                      echo "Correct Client Package according to the given architecture type."
                 else
-                      echo "Incorrect Client Package according to the given offertype"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                      echo "Incorrect Client Package according to the given architecture type."               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
                 fi 
           fi                            
   register: output_offertype_except_byol

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -155,7 +155,7 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          client_package=$( rpm-qa | grep rhui ) 
+          client_package=$( rpm -qa | grep rhui ) 
           echo $client_package
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               echo "statement 1"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -189,7 +189,8 @@
           done 
             offer_within_clientpkg="${offer_within_clientpkg%?}"
             echo $offer_within_clientpkg    
-            if [[ $offer_type == $offer_within_clientpkg ]]; then 
+            echo  {{ offer_type }} 
+            if [[ {{ offer_type }} == $offer_within_clientpkg ]]; then 
                   echo "Correct Client Package according to the given offertype"
             else
                   echo "Incorrect Client Package according to the given offertype"
@@ -204,7 +205,7 @@
 - name: "Write to error msg if incorrect client package is present according to the offertype"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n Incorrect Client Package is present according to the offertype."
+    line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
   when: ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines) and ( offer_type!='byol')

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -156,6 +156,7 @@
     cmd: |
       #!/bin/bash
           client_package=$(rpm-qa | grep rhui) 
+          echo $client_package
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               echo "statement 1"
               clientpkgwithoutarchitecture=""

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -164,7 +164,7 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-           client_package={{ output_client_package.stdout_lines[0] }} 
+          client_package={{ output_client_package.stdout_lines[0] }} 
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               echo "statement 1"
               clientpkgwithoutarchitecture=""
@@ -176,7 +176,8 @@
               substring="rhui-azure-rhel9-"
               string_without_substring="${client_package//$substring/}"
               echo $string_without_substring
-              offerval="${string_without_substring%%[0-9]*}"          
+              offerval="${string_without_substring%%[0-9]*}"   
+              echo $offerval       
               offer_in_rhel_image=${offerval//-/}
               offertype={{ offer_type }}
               offertype=${offertype//-/}

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -151,6 +151,30 @@
     state: present 
   when: offer_type =='byol' and rhui_package_count != "0"
 
+
+- name: Check if the client package is present according to correct architecture
+  ansible.builtin.shell:
+    cmd: |
+      #!/bin/bash
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                          ## if the architecture is arm64 based then client package value will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
+                check_correctness=$( rpm -qa | grep arm64 ) 
+                if [[ -z "$check_correctness" ]]; then 
+                      echo "Incorrect Client Package according to the given offertype"
+                else
+                      echo "Client Package according to the given offertype"                
+                fi 
+          else
+                check_correctness=$( rpm -qa | grep arm64 ) 
+                if [[ -z "$check_correctness" ]]; then 
+                      echo "Correct Client Package according to the given offertype"
+                else
+                      echo "Incorrect Client Package according to the given offertype"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                fi 
+          fi                            
+  register: output_offertype_except_byol
+  when: offer_type !='byol'                       
+
+
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol.
   ansible.builtin.shell:
     cmd: |
@@ -163,9 +187,9 @@
           fi                            
                                                           
                       
-              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')
-              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')
-              
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Extract suffix -2.3-5343.noarch.rpm from client package
+              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')                                    ## Extract prefix rhui-azure-rhel8- val from client package
+
               offertype={{ offer_type }}
               offertype=${offertype//-/}  
               extract_offer_val=${extract_offer_val//-/}

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,7 +159,14 @@
 - debug:
     var: output_client_package
 
-- name: Check if the client package is present according to the offertype when offertype is not equal to byol.
+- name: Check the value of architecture
+  shell: echo {{ architecture }}
+  register: output_architecture
+
+- debug:
+    var: output_architecture
+
+- name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
@@ -205,7 +212,7 @@
 - debug:
     var: output_offertype_except_byol 
 
-- name: "Write to error msg if incorrect client package is present according to the offertype"
+- name: "Write to error msg if incorrect client package is present according to the offertype and architecture is equal to x86-64"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,35 +159,31 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                              ## if the architecture is arm64 based then client package value will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
               substring="arm64-"                                                       ## The value of client packages for architecture type x86-64 don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
               clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
-              echo $clientpkgwithoutarchitecture
               client_package=$clientpkgwithoutarchitecture                            
           fi                            
                                                           
-              substring="${client_package:0:17}"                                       ## The substring "rhui-azure-rhel9-" will be eliminated from the variable which contains the value of client package.
-              client_pkg_without_substring="${client_package//$substring/}"            ## After removing the above substring, the remaining string will be equal to "offer"+"build numer"+ noarch value. Example string: eus-2.3-655.noarch. For base client packages, it should be only 2.3-655.noarch. This value is getting stored in string_without_substring variable.
-              echo $client_pkg_without_substring
-              offerval="${client_pkg_without_substring%%[0-9]*}"                           ## The value of the offertype which is present in the name of client package is getting calculated from string_without_substring variable. It will be equal to eus-, sap-apps-, sap-ha- etc values. For base offertypes, it will be equal to - .This value is getting stored in offerval variable.
-              echo $offerval       
-              offer_in_rhel_image=${offerval//-/}                                      ## In this command, all the hyphens are being removed from the above substring. This is important because the value of sap-apps client package is rhui-azure-rhel8-sapapps-2.3-5272.noarch. Hyphen needs to be removed to equate the offertype values. Client Package Pipeline Build Run: https://msazure.visualstudio.com/One/_build/results?buildId=93555256&view=artifacts&pathAsName=false&type=publishedArtifacts
-              offertype={{ offer_type }}
-              offertype=${offertype//-/}                                               ## In this command, all the hyphens are being removed from the {{ offer_type }} variable which is being supplied through the pipeline and the output is stored in the offertype variable.
+                      
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')
+              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')
 
+              offertype=${offertype//-/}  
+              extract_offer_val=${extract_offer_val//-/}
 
               echo "Print the value of the offertype passed in the pipeline variables: " $offertype
-              echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_image
+              echo "Print the value of the offertype which is present the client package name: " $extract_offer_val
   
-
               if [[  $offertype  == "base" ]]; then
-                  if [[ -z "$offer_in_rhel_image" ]]; then 
+                  if [[ -z "$extract_offer_val" ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
-                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of offer_in_rhel_image variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
+
               else    
-                  if [[ $offertype == $offer_in_rhel_image ]]; then 
+                  if [[ $offertype == $extract_offer_val ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
-                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of offer_in_rhel_image variable should not be null.
+                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
                   fi   
               fi
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -171,7 +171,7 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if ( "{{ architecture }}" -ne "arm64"); then
+          if [[ "{{ architecture }}" -ne "arm64" ]]; then
               client_package={{ output_client_package.stdout_lines[0] }}   ##debug
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -157,11 +157,10 @@
       #!/bin/bash
           client_package=$( rpm -qa | grep rhui ) 
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
-              clientpkgwithoutarchitecture=""
               substring="arm64"
-              clientpkgwithoutarchitecture = "${client_package//$substring/}"
+              clientpkgwithoutarchitecture="${client_package//$substring/}"
               echo $clientpkgwithoutarchitecture
-              client_package=clientpkgwithoutarchitecture
+              client_package=$clientpkgwithoutarchitecture
           fi
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -226,10 +226,9 @@
     cmd: |
       #!/bin/bash
             offer_within_clientpkg=""
+            client_package={{ output_client_package.stdout_lines[0] }}
             len="$(echo -n "$client_package" | wc -c)"
             for (( i=17; i<len; i++  ));
-                 echo "Debug statement"
-                 echo "${client_package:i:1}"
               do
                 if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
                       break;

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -159,11 +159,11 @@
     state: present 
   when: offer_type =='byol' and rhui_package_count != "0"
 
-- name: Check if the client package is present according to correct architecture
+- name: Check if the correct client package is present according to the architecture type
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                          ## if the architecture is arm64 based then client package value will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
                       echo "Incorrect Client Package according to the given offertype"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -107,7 +107,7 @@
     when: ("pci" not in check_pci_allimages.stdout)
 
 - name: Check for Rhui client package in the image
-  when: license_type != 'byol'
+  when: license_type != 'byos'
   block:
   - name: Gather the package facts
     ansible.builtin.package_facts:
@@ -141,102 +141,9 @@
       is_rhui_package_present : true
     when: rhui_package_count != "0"
 
-##Repo Validation Task
-
-- name: Check if more than 1 client package is present in the RHEL Image
-  lineinfile:
-    path: "{{err_folder}}/err_msgs.log"
-    line: "\n  The RHEL Image contains more than 1 client package"
-    create: yes
-    state: present 
-  when: rhui_package_count > "1"
-
-- name: Check if offertype is equal to byol and client package is present
-  lineinfile:
-    path: "{{err_folder}}/err_msgs.log"
-    line: "\n  Client Package is present in BYOL Offertype Image. Details of the client package {{ rhui_package }}"
-    create: yes
-    state: present 
-  when: offer_type =='byol' and rhui_package_count != "0"
-
-- name: Check if the correct client package is present according to the architecture type
-  ansible.builtin.shell:
-    cmd: |
-      #!/bin/bash
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
-                check_correctness=$( rpm -qa | grep arm64 ) 
-                if [[ -z "$check_correctness" ]]; then 
-                      echo "Client Package does not contain the value of arm64 architecture type."
-                else
-                      echo "Client Package contains the value of arm64 architecture type."                
-                fi 
-          else
-                check_correctness=$( rpm -qa | grep arm64 ) 
-                if [[ -z "$check_correctness" ]]; then 
-                      echo "Correct Client Package is correct. It does not contain the value of arm64 architecture type"
-                else
-                      echo "Client Package according to the given architecture type. It contains the value of arm64 architecture type"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
-                fi 
-          fi                            
-  register: output_offertype_except_byol
-  when: offer_type !='byol'                       
-
-- debug:
-    var: output_offertype_except_byol 
-
-- name: Check if the client package is present according to the offertype when offertype is not equal to byol.
-  ansible.builtin.shell:
-    cmd: |
-      #!/bin/bash
-          client_package=$( rpm -qa | grep rhui )                                      ## Value of client package is getting calculated
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then                              
-              substring="arm64-"                                                       
-              clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
-              client_package=$clientpkgwithoutarchitecture                            
-          fi                            
-                                                          
-                      
-              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Eliminate the suffix  "-2.3-5343.noarch.rpm"  from client package. Remaining value should be equal to "rhui-azure-rhel8" + "offertype" | Examples: "rhui-azure-rhel8", "rhui-azure-rhel8-eus", "rhui-azure-rhel8-sap-ha"
-              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix rhui-azure-rhel8"  value from client package
-              extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                   ## For Base Offertype, extract_offer_val should be equal to null.
-
-
-              offertype={{ offer_type }}
-              offertype=${offertype//-/}  
-              extract_offer_val=${extract_offer_val//-/}
-
-              echo "Print the value of the offertype passed in the pipeline variables: " $offertype
-              echo "Print the value of the offertype which is present the client package name: " $extract_offer_val
-  
-              if [[  $offertype  == "base" ]]; then
-                  if [[ -z "$extract_offer_val" ]]; then 
-                        echo "Correct Client Package according to the given offertype"
-                  else
-                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
-                  fi   
-
-              else    
-                  if [[ $offertype == $extract_offer_val ]]; then 
-                        echo "Correct Client Package according to the given offertype"
-                  else
-                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
-                  fi   
-              fi
-
-  register: output_offertype_except_byol
-  when: offer_type !='byol' 
-
-- debug:
-    var: output_offertype_except_byol 
-
-- name: "Write to error msg if incorrect client package is present according to the offertype"
-  lineinfile:
-    path: "{{err_folder}}/err_msgs.log"
-    line: "\n Incorrect Client Package is present according to the offertype {{ offer_type }}."
-    create: yes
-    state: present 
-  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
-
+- name: Check the repo-validation
+  include_tasks: validation-playbooks/repo-validation-check.yaml
+  ignore_errors: yes
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.
   when: isCVM is false and ansible_distribution_major_version == '9'

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -178,8 +178,8 @@
               string_without_substring="${client_package//$substring/}"
               offerval="${string_without_substring%%[0-9]*}"          
               offer_in_rhel_image=${offerval//-/}
-              offer_type={{ offer_type }}
-              offer_type=${ offer_type//-/}
+              offertype={{ offer_type }}
+              offertype=${offertype//-/}
               echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
               offer_within_clientpkg=${offer_within_clientpkg//-/}

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -184,7 +184,7 @@
                   fi   
               else    
                   echo "block 2"
-                  if [[ $offer_type == $offer_in_rhel_image ]]; then 
+                  if [[ $offertype == $offer_in_rhel_image ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
                         echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of offer_in_rhel_image variable should not be null.

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -221,6 +221,50 @@
   when: ( offer_type!='byol') and ( architecture == "x86-64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
 
+- name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to arm64.
+  ansible.builtin.shell:
+    cmd: |
+      #!/bin/bash
+            offer_within_clientpkg=""
+            len="$(echo -n "$client_package" | wc -c)"
+            for (( i=17; i<len; i++  ));
+              do
+                if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
+                      break;
+                else
+                      offer_within_clientpkg="${offer_within_clientpkg}${client_package:i:1}"
+                fi  
+            done 
+              echo  {{ offer_type }} 
+              echo $offer_within_clientpkg         
+              if [[ {{ offer_type }} == "base" ]]; then         
+                    if [[ $offer_within_clientpkg == "arm" ]]; then
+                        echo "Correct Client Package according to the given offertype"
+                    else
+                        echo "Incorrect Client Package according to the given offertype"
+                    fi
+              else
+                    if [[ $offer_within_clientpkg == "eus-arm" ]]; then
+                        echo "Correct Client Package according to the given offertype"
+                    else
+                        echo "Incorrect Client Package according to the given offertype"
+                    fi
+              fi   
+
+  register: output_offertype_except_byol_arm64
+  when: offer_type !='byol' and  architecture == "arm64"
+
+- debug:
+    var: output_offertype_except_byol_arm64 
+
+- name: "Write to error msg if incorrect client package is present according to the offertype and architecture is equal to arm64"
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
+    create: yes
+    state: present 
+  when: ( offer_type!='byol') and ( architecture == "arm64" ) and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol_arm64.stdout_lines)  
+
 - name: Check for the Accelerated Networking in Rhel 9 Images.
   when: isCVM is false and ansible_distribution_major_version == '9'
   block:

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -160,7 +160,7 @@
     var: output_client_package
 
 
-- name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
+- name: Check if the client package is present according to the offertype when offertype is not equal to byol.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
@@ -186,18 +186,27 @@
               echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
               offer_within_clientpkg=${offer_within_clientpkg//-/}
-              if [[ {{ offer_type }}  == $offer_in_rhel_imag ]]; then 
-                    echo "Correct Client Package according to the given offertype"
-              else
-                    echo "Incorrect Client Package according to the given offertype"
-              fi       
+              if [[ {{ offer_type }} == "base" ]]; then
+                  if [[ -z "$offer_in_rhel_imag" ]]; then 
+                        echo "Correct Client Package according to the given offertype"
+                  else
+                        echo "Incorrect Client Package according to the given offertype"
+                  fi   
+              else    
+                  if [[ {{ offer_type }}  == $offer_in_rhel_imag ]]; then 
+                        echo "Correct Client Package according to the given offertype"
+                  else
+                        echo "Incorrect Client Package according to the given offertype"
+                  fi   
+              fi
+
   register: output_offertype_except_byol
   when: offer_type !='byol' 
 
 - debug:
     var: output_offertype_except_byol 
 
-- name: "Write to error msg if incorrect client package is present according to the offertype and architecture is equal to x86-64"
+- name: "Write to error msg if incorrect client package is present according to the offertype"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -189,15 +189,15 @@
     cmd: |
       #!/bin/bash
           client_package=$( rpm -qa | grep rhui )                                      ## Value of client package is getting calculated
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then                              ## if the architecture is arm64 based then client package value will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
-              substring="arm64-"                                                       ## The value of client packages for architecture type x86-64 don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                              
+              substring="arm64-"                                                       
               clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
               client_package=$clientpkgwithoutarchitecture                            
           fi                            
                                                           
                       
-              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Extract suffix -2.3-5343.noarch.rpm from client package
-              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')                                    ## Extract prefix rhui-azure-rhel8- val from client package
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Extract suffix  "-2.3-5343.noarch.rpm"  from client package
+              extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')                                    ## Extract prefix  "rhui-azure-rhel8-""  val from client package
 
               offertype={{ offer_type }}
               offertype=${offertype//-/}  

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -156,14 +156,12 @@
     cmd: |
       #!/bin/bash
           client_package=$( rpm -qa | grep rhui ) 
-          echo $client_package
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
-              echo "statement 1"
               clientpkgwithoutarchitecture=""
               substring="arm64"
               clientpkgwithoutarchitecture="${client_package//$substring/}"
+              echo $clientpkgwithoutarchitecture
               client_package=clientpkgwithoutarchitecture
-              echo $client_package
           fi
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -166,6 +166,7 @@
       #!/bin/bash
            client_package={{ output_client_package.stdout_lines[0] }} 
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
+              echo "statement 1"
               clientpkgwithoutarchitecture=""
               substring="arm64"
               clientpkgwithoutarchitecture="${client_package//$substring/}"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -208,7 +208,7 @@
     line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
-  when: ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines) and ( offer_type!='byol')
+  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
 
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -165,7 +165,8 @@
                       
               package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')
               extract_offer_val=$(echo $package_type | sed -E 's/^[^-]+-[^-]+-[^-]+-//')
-
+              
+              offertype={{ offer_type }}
               offertype=${offertype//-/}  
               extract_offer_val=${extract_offer_val//-/}
 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -189,7 +189,7 @@
           done 
             offer_within_clientpkg="${offer_within_clientpkg%?}"
             echo $offer_within_clientpkg    
-            if [[ $offer_type == $concatenated ]]; then 
+            if [[ $offer_type == $offer_within_clientpkg ]]; then 
                   echo "Correct Client Package according to the given offertype"
             else
                   echo "Incorrect Client Package according to the given offertype"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -161,7 +161,8 @@
               clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
               echo $clientpkgwithoutarchitecture
               client_package=$clientpkgwithoutarchitecture                            
-          fi                                                                            
+          fi                            
+                                                          
               substring="${client_package:0:17}"                                       ## The substring "rhui-azure-rhel9-" will be eliminated from the variable which contains the value of client package.
               client_pkg_without_substring="${client_package//$substring/}"            ## After removing the above substring, the remaining string will be equal to "offer"+"build numer"+ noarch value. Example string: eus-2.3-655.noarch. For base client packages, it should be only 2.3-655.noarch. This value is getting stored in string_without_substring variable.
               echo $client_pkg_without_substring
@@ -171,19 +172,18 @@
               offertype={{ offer_type }}
               offertype=${offertype//-/}                                               ## In this command, all the hyphens are being removed from the {{ offer_type }} variable which is being supplied through the pipeline and the output is stored in the offertype variable.
 
+
               echo "Print the value of the offertype passed in the pipeline variables: " $offertype
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_image
-              offer_within_clientpkg=${offer_within_clientpkg//-/}
+  
 
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$offer_in_rhel_image" ]]; then 
-                        echo "block 1"
                         echo "Correct Client Package according to the given offertype"
                   else
                         echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of offer_in_rhel_image variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
               else    
-                  echo "block 2"
                   if [[ $offertype == $offer_in_rhel_image ]]; then 
                         echo "Correct Client Package according to the given offertype"
                   else
@@ -200,7 +200,7 @@
 - name: "Write to error msg if incorrect client package is present according to the offertype"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n Incorrect Client Package {{  output_client_package.stdout_lines[0] }} is present according to the offertype {{ offer_type }}."
+    line: "\n Incorrect Client Package is present according to the offertype {{ offer_type }}."
     create: yes
     state: present 
   when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -166,6 +166,13 @@
 - debug:
     var: output_architecture
 
+## Logic: Example client package for x86-64 based architecture: rhui-azure-rhel9-eus-2.3-655.noarch. This client package contains eus based offertype. 
+## For BYOL offertype, this task is getting skippied.
+## According to the below logic, if the offertype value present inside the client package is different from the offertype value which is being supplied through the pipeline variables,It indicates that incorrect client package is present inside the RHEL Image according to the given offertype.
+## For base offertype, client package naming should not contain any offertype value. The below logic is iterating through the list of all the offertypes and checks if the value of any offertype is also present in the client package naming.
+## For the offers other than base and byol, the logic is iterating from the index 17 which means that it is skipping "rhui-azure-rhel9-"" portion of client package naming and only extracts the offertype whcih is present in the client package naming itself and storing it in a variable offer_within_clientpkg.
+## offer_within_clientpkg is equated against the {{ offer_type }} variable which is being supplied through the pipeline variables. If the correct client package is present, then the value of offer_within_clientpkg should be equal to the {{ offer_type }} variable.
+
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol and architecture is equal to x86-64.
   ansible.builtin.shell:
     cmd: |

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -233,8 +233,6 @@
                 if [[ "${client_package:i:1}" =~ ^[0-9]+$ ]]; then
                       break;
                 else
-                      echo "Debug statement"
-                      echo "${client_package:i:1}"
                       offer_within_clientpkg="${offer_within_clientpkg}${client_package:i:1}"
                 fi  
             done 

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -155,7 +155,7 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          client_package=$(rpm-qa | grep rhui) 
+          client_package=$( rpm-qa | grep rhui ) 
           echo $client_package
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
               echo "statement 1"

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -171,13 +171,15 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if ( {{ architecture != "arm64"}}); then
+          if ( {{ architecture }} != "arm64"); then
               client_package={{ output_client_package.stdout_lines[0] }} 
               offer_in_rhel_image=""
               substring="rhui-azure-rhel9-"
               string_without_substring="${client_package//$substring/}"
               offerval="${string_without_substring%%[0-9]*}"          
               offer_in_rhel_image=${offerval//-/}
+              offer_type={{ offer_type }}
+              offer_type=${ offer_type//-/}
               echo "Print the value of the offertype passed in the pipeline variables: " {{ offer_type }} 
               echo "Print the value of the offertype which is present the client package name: " $offer_in_rhel_imag
               offer_within_clientpkg=${offer_within_clientpkg//-/}

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -157,7 +157,7 @@
       #!/bin/bash
           client_package=$( rpm -qa | grep rhui ) 
           if [[ "{{ architecture }}" -eq "arm64" ]]; then
-              substring="arm64"
+              substring="arm64-"
               clientpkgwithoutarchitecture="${client_package//$substring/}"
               echo $clientpkgwithoutarchitecture
               client_package=$clientpkgwithoutarchitecture

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -1,5 +1,12 @@
 ##This playbook checks if the RHEL Images contain client packages according to the offer type and architecture of the Image.
 
+- hosts: all
+  tasks:
+    - name: Print the value of a variable
+      debug:
+        msg: "The value of the variable is {{ offer_type }} , {{ architecture }} , {{ rhui_package_count }} , {{ rhui_package }} "
+
+
 - name: Check if more than 1 client package is present in the RHEL Image
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -3,11 +3,11 @@
 
 - name: Set the variable if rhui client package is correct according to the given offertype
   set_fact:
-    PrintResultofCorrectPackage : "Correct Client Package according to the given offertype"
+    PrintResultofCorrectPackage : "Correct Client Package according to the given offertype {{ offer_type }}"
 
 - name: Set the variable if rhui client package is incorrect according to the given offertype
   set_fact:
-    PrintResultofIncorrectPackage : "Incorrect Client Package according to the given offertype"
+    PrintResultofIncorrectPackage : "Incorrect Client Package according to the given offertype {{ offer_type }}"
 
 - name: Print the value of a variable
   debug:
@@ -81,16 +81,16 @@
   
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$extract_offer_val" ]]; then 
-                        echo " PrintResultofCorrectPackage"
+                        echo "{{ PrintResultofCorrectPackage }}"
                   else
-                        echo " PrintResultofInorrectPackage"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo "{{ PrintResultofInorrectPackage }}"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
 
               else    
                   if [[ $offertype == $extract_offer_val ]]; then 
-                        echo " PrintResultofCorrectPackage"
+                        echo "{{ PrintResultofCorrectPackage }}"
                   else
-                        echo " PrintResultofIncorrectPackage"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
+                        echo "{{ PrintResultofIncorrectPackage }}"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
                   fi   
               fi
 

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -1,13 +1,20 @@
 ##This playbook checks if the RHEL Images contain client packages according to the offer type and architecture of the Image.
 
+- name: Set the variable if rhui client package is correct according to the given architecturetype
+  set_fact:
+    CorrectPackageAccToArch : "Correct Client Package according to the given architecture {{ architecture }}."
+
+- name: Set the variable if rhui client package is incorrect according to the given architecturetype
+  set_fact:
+    IncorrectPackageAccToArch : "Incorrect Client Package according to the given architecture {{ architecture }}."
 
 - name: Set the variable if rhui client package is correct according to the given offertype
   set_fact:
-    PrintResultofCorrectPackage : "Correct Client Package according to the given offertype {{ offer_type }}"
+    CorrectPackageAccToOffer : "Correct Client Package according to the given offertype {{ offer_type }}."
 
 - name: Set the variable if rhui client package is incorrect according to the given offertype
   set_fact:
-    PrintResultofIncorrectPackage : "Incorrect Client Package according to the given offertype {{ offer_type }}"
+    IncorrectPackageAccToOffer : "Incorrect Client Package according to the given offertype {{ offer_type }}."
 
 - name: Print the value of a variable
   debug:
@@ -34,35 +41,46 @@
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                                                  ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Client Package is incorrect according to the given architecturetype {{ architecture }}. It does not contain the substring arm64 in the client package. "
+                      echo "{{ CorrectPackageAccToArch }}"
                 else
-                      echo "Correct Client Package is correct according to the given architecturetype {{ architecture }}. It contains the substring arm64 in the client package. "                
+                      echo "{{ IncorrectPackageAccToArch }} "                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Correct Client Package is correct according to the given architecturetype {{ architecture }}. It does not contain the substring arm64 in the client package. "
+                      echo "{{ CorrectPackageAccToArch }}"
                 else
-                      echo "Client Package is incorrect according to the given architecturetype {{ architecture }}. It contains the substring arm64 in the client package. "               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                      echo " {{ IncorrectPackageAccToArch }}"                                                               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 or x86-64 as a substring. Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
                 fi 
           fi                            
-  register: output_offertype_except_byol
+  register: output_package_acc_architecture
   when: offer_type !='byol'                       
 
 - debug:
-    var: output_offertype_except_byol 
+    var: output_package_acc_architecture
+
+
+- name: "Write to error msg if incorrect client package is present according to the architecture"
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n {{ IncorrectPackageAccToArch }}"
+    create: yes
+    state: present 
+  when: ( offer_type!='byol') and ("{{ IncorrectPackageAccToArch }}" in output_package_acc_architecture.stdout_lines)  
+
+
 
 - name: Check if the client package is present according to the offertype when offertype is not equal to byol.
   ansible.builtin.shell:
     cmd: |
       #!/bin/bash
-          client_package=$( rpm -qa | grep rhui )                                      ## Value of client package is getting calculated
+          client_package=$( rpm -qa | grep rhui )                                                                           ## Value of client package is getting calculated
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                              
               substring="arm64-"                                                       
-              clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
+              clientpkgwithoutarchitecture="${client_package//$substring/}"                                                 ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
               client_package=$clientpkgwithoutarchitecture                            
           fi                            
                                                           
@@ -81,16 +99,16 @@
   
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$extract_offer_val" ]]; then 
-                        echo "{{ PrintResultofCorrectPackage }}"
+                        echo "{{ CorrectPackageAccToOffer }}"
                   else
-                        echo "{{ PrintResultofIncorrectPackage }}"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo "{{ IncorrectPackageAccToOffer }}"                                                             ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of Base Offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
 
               else    
                   if [[ $offertype == $extract_offer_val ]]; then 
-                        echo "{{ PrintResultofCorrectPackage }}"
+                        echo "{{ CorrectPackageAccToOffer }}"
                   else
-                        echo "{{ PrintResultofIncorrectPackage }}"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
+                        echo "{{ IncorrectPackageAccToOffer }}"                                                             ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null. Example of client package other than Base Offertype: "rhui-azure-rhel9-eus-2.3-655.noarch" .
                   fi   
               fi
 
@@ -103,8 +121,8 @@
 - name: "Write to error msg if incorrect client package is present according to the offertype"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n Incorrect Client Package is present according to the offertype {{ offer_type }}."
+    line: "\n {{ IncorrectPackageAccToOffer }}"
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
+  when: ( offer_type!='byol') and ("{{ IncorrectPackageAccToOffer }}" in output_offertype_except_byol.stdout_lines)  
 

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -1,10 +1,9 @@
 ##This playbook checks if the RHEL Images contain client packages according to the offer type and architecture of the Image.
 
-- hosts: all
-  tasks:
-    - name: Print the value of a variable
-      debug:
-        msg: "The value of the variable is {{ offer_type }} , {{ architecture }} , {{ rhui_package_count }} , {{ rhui_package }} "
+
+- name: Print the value of a variable
+  debug:
+      msg: "The value of the variable is {{ offer_type }} , {{ architecture }} , {{ rhui_package_count }} , {{ rhui_package }} "
 
 
 - name: Check if more than 1 client package is present in the RHEL Image

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -44,9 +44,9 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                                                                  ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "{{ CorrectPackageAccToArch }}"
+                      echo "{{ IncorrectPackageAccToArch }}"
                 else
-                      echo "{{ IncorrectPackageAccToArch }} "                
+                      echo "{{ CorrectPackageAccToArch }} "                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -1,0 +1,96 @@
+##This playbook checks if the RHEL Images contain client packages according to the offer type and architecture of the Image.
+
+- name: Check if more than 1 client package is present in the RHEL Image
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n  The RHEL Image contains more than 1 client package"
+    create: yes
+    state: present 
+  when: rhui_package_count > "1"
+
+- name: Check if offertype is equal to byol and client package is present
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n  Client Package is present in BYOL Offertype Image. Details of the client package {{ rhui_package }}"
+    create: yes
+    state: present 
+  when: offer_type =='byol' and rhui_package_count != "0"
+
+- name: Check if the correct client package is present according to the architecture type
+  ansible.builtin.shell:
+    cmd: |
+      #!/bin/bash
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
+                check_correctness=$( rpm -qa | grep arm64 ) 
+                if [[ -z "$check_correctness" ]]; then 
+                      echo "Client Package does not contain the value of arm64 architecture type."
+                else
+                      echo "Client Package contains the value of arm64 architecture type."                
+                fi 
+          else
+                check_correctness=$( rpm -qa | grep arm64 ) 
+                if [[ -z "$check_correctness" ]]; then 
+                      echo "Correct Client Package is correct. It does not contain the value of arm64 architecture type"
+                else
+                      echo "Client Package according to the given architecture type. It contains the value of arm64 architecture type"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                fi 
+          fi                            
+  register: output_offertype_except_byol
+  when: offer_type !='byol'                       
+
+- debug:
+    var: output_offertype_except_byol 
+
+- name: Check if the client package is present according to the offertype when offertype is not equal to byol.
+  ansible.builtin.shell:
+    cmd: |
+      #!/bin/bash
+          client_package=$( rpm -qa | grep rhui )                                      ## Value of client package is getting calculated
+          if [[ "{{ architecture }}" -eq "arm64" ]]; then                              
+              substring="arm64-"                                                       
+              clientpkgwithoutarchitecture="${client_package//$substring/}"            ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
+              client_package=$clientpkgwithoutarchitecture                            
+          fi                            
+                                                          
+                      
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Eliminate the suffix  "-2.3-5343.noarch.rpm"  from client package. Remaining value should be equal to "rhui-azure-rhel8" + "offertype" | Examples: "rhui-azure-rhel8", "rhui-azure-rhel8-eus", "rhui-azure-rhel8-sap-ha"
+              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix rhui-azure-rhel8"  value from client package
+              extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                   ## For Base Offertype, extract_offer_val should be equal to null.
+
+
+              offertype={{ offer_type }}
+              offertype=${offertype//-/}  
+              extract_offer_val=${extract_offer_val//-/}
+
+              echo "Print the value of the offertype passed in the pipeline variables: " $offertype
+              echo "Print the value of the offertype which is present the client package name: " $extract_offer_val
+  
+              if [[  $offertype  == "base" ]]; then
+                  if [[ -z "$extract_offer_val" ]]; then 
+                        echo "Correct Client Package according to the given offertype"
+                  else
+                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                  fi   
+
+              else    
+                  if [[ $offertype == $extract_offer_val ]]; then 
+                        echo "Correct Client Package according to the given offertype"
+                  else
+                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
+                  fi   
+              fi
+
+  register: output_offertype_except_byol
+  when: offer_type !='byol' 
+
+- debug:
+    var: output_offertype_except_byol 
+
+- name: "Write to error msg if incorrect client package is present according to the offertype"
+  lineinfile:
+    path: "{{err_folder}}/err_msgs.log"
+    line: "\n Incorrect Client Package is present according to the offertype {{ offer_type }}."
+    create: yes
+    state: present 
+  when: ( offer_type!='byol') and ("Incorrect Client Package according to the given offertype" in output_offertype_except_byol.stdout_lines)  
+

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -90,9 +90,9 @@
               extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                      ## For Base Offertype, extract_offer_val should be equal to null.
 
 
-              offertype={{ offer_type }}
+              offertype={{ offer_type }}                                                                                       ## The value of offertype is passed through pipeline variables. Example: "base", "eus", "sap-ha"
               offertype=${offertype//-/}  
-              extract_offer_val=${extract_offer_val//-/}
+              extract_offer_val=${extract_offer_val//-/}                                                                       ## The "-" is removed from the offertype and extract_offer_val variable so that the comparison can be done without any special characters.
 
               echo "Print the value of the offertype passed in the pipeline variables: " $offertype
               echo "Print the value of the offertype which is present the client package name: " $extract_offer_val

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -1,6 +1,14 @@
 ##This playbook checks if the RHEL Images contain client packages according to the offer type and architecture of the Image.
 
 
+- name: Set the variable if rhui client package is correct according to the given offertype
+  set_fact:
+    PrintResultofCorrectPackage : "Correct Client Package according to the given offertype"
+
+- name: Set the variable if rhui client package is incorrect according to the given offertype
+  set_fact:
+    PrintResultofIncorrectPackage : "Incorrect Client Package according to the given offertype"
+
 - name: Print the value of a variable
   debug:
       msg: "The value of the variable is Offetype: {{ offer_type }} , Architecture_type: {{ architecture }} , RhuiPackageCount: {{ rhui_package_count }} , RhuiPackageDetails:{{ rhui_package }} "
@@ -73,16 +81,16 @@
   
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$extract_offer_val" ]]; then 
-                        echo "Correct Client Package according to the given offertype"
+                        echo " PrintResultofCorrectPackage"
                   else
-                        echo "Incorrect Client Package according to the given offertype"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo " PrintResultofInorrectPackage"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
 
               else    
                   if [[ $offertype == $extract_offer_val ]]; then 
-                        echo "Correct Client Package according to the given offertype"
+                        echo " PrintResultofCorrectPackage"
                   else
-                        echo "Incorrect Client Package according to the given offertype"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
+                        echo " PrintResultofIncorrectPackage"        ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null.
                   fi   
               fi
 

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -12,7 +12,7 @@
     line: "\n  The RHEL Image contains more than 1 client package"
     create: yes
     state: present 
-  when: rhui_package_count > "1"
+  when: ( rhui_package_count | int ) > 1
 
 - name: Check if offertype is equal to byol and client package is present
   lineinfile:

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -3,7 +3,7 @@
 
 - name: Print the value of a variable
   debug:
-      msg: "The value of the variable is {{ offer_type }} , {{ architecture }} , {{ rhui_package_count }} , {{ rhui_package }} "
+      msg: "The value of the variable is Offetype: {{ offer_type }} , Architecture_type: {{ architecture }} , RhuiPackageCount: {{ rhui_package_count }} , RhuiPackageDetails: {{ rhui_package }} "
 
 
 - name: Check if more than 1 client package is present in the RHEL Image

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -83,7 +83,7 @@
                   if [[ -z "$extract_offer_val" ]]; then 
                         echo "{{ PrintResultofCorrectPackage }}"
                   else
-                        echo "{{ PrintResultofInorrectPackage }}"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo "{{ PrintResultofIncorrectPackage }}"        ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of base offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
 
               else    

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -3,7 +3,7 @@
 
 - name: Print the value of a variable
   debug:
-      msg: "The value of the variable is Offetype: {{ offer_type }} , Architecture_type: {{ architecture }} , RhuiPackageCount: {{ rhui_package_count }} , RhuiPackageDetails: {{ rhui_package }} "
+      msg: "The value of the variable is Offetype: {{ offer_type }} , Architecture_type: {{ architecture }} , RhuiPackageCount: {{ rhui_package_count }} , RhuiPackageDetails:{{ rhui_package }} "
 
 
 - name: Check if more than 1 client package is present in the RHEL Image
@@ -29,16 +29,16 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                                            ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Client Package does not contain the value of arm64 architecture type."
+                      echo "Client Package is incorrect according to the given architecturetype {{ architecture }}. It does not contain the substring arm64 in the client package. "
                 else
-                      echo "Client Package contains the value of arm64 architecture type."                
+                      echo "Correct Client Package is correct according to the given architecturetype {{ architecture }}. It contains the substring arm64 in the client package. "                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "Correct Client Package is correct. It does not contain the value of arm64 architecture type"
+                      echo "Correct Client Package is correct according to the given architecturetype {{ architecture }}. It does not contain the substring arm64 in the client package. "
                 else
-                      echo "Client Package according to the given architecture type. It contains the value of arm64 architecture type"               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                      echo "Client Package is incorrect according to the given architecturetype {{ architecture }}. It contains the substring arm64 in the client package. "               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
                 fi 
           fi                            
   register: output_offertype_except_byol

--- a/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
+++ b/ansible_image_validation/validation-playbooks/repo-validation-check.yaml
@@ -2,19 +2,19 @@
 
 - name: Set the variable if rhui client package is correct according to the given architecturetype
   set_fact:
-    CorrectPackageAccToArch : "Correct Client Package according to the given architecture {{ architecture }}."
+    Correct_Package_Acc_To_Arch : "Correct Client Package according to the given architecture {{ architecture }}."
 
 - name: Set the variable if rhui client package is incorrect according to the given architecturetype
   set_fact:
-    IncorrectPackageAccToArch : "Incorrect Client Package according to the given architecture {{ architecture }}."
+    Incorrect_Package_Acc_To_Arch : "Incorrect Client Package according to the given architecture {{ architecture }}."
 
 - name: Set the variable if rhui client package is correct according to the given offertype
   set_fact:
-    CorrectPackageAccToOffer : "Correct Client Package according to the given offertype {{ offer_type }}."
+    Correct_Package_Acc_To_Offer : "Correct Client Package according to the given offertype {{ offer_type }}."
 
 - name: Set the variable if rhui client package is incorrect according to the given offertype
   set_fact:
-    IncorrectPackageAccToOffer : "Incorrect Client Package according to the given offertype {{ offer_type }}."
+    Incorrect_Package_Acc_To_Offer : "Incorrect Client Package according to the given offertype {{ offer_type }}."
 
 - name: Print the value of a variable
   debug:
@@ -44,16 +44,16 @@
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                                                                  ## This if block refers to the check for the client packages of arm64 architecture type.  The client packages of arm64 architecture is arm64  will contain arm64 as a substring.Example client package: "rhui-azure-rhel9-eus-arm64-2.3-655.noarch","rhui-azure-rhel9-arm64-2.3-655.noarch"
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "{{ IncorrectPackageAccToArch }}"
+                      echo "{{ Incorrect_Package_Acc_To_Arch }}"
                 else
-                      echo "{{ CorrectPackageAccToArch }} "                
+                      echo "{{ Correct_Package_Acc_To_Arch }} "                
                 fi 
           else
                 check_correctness=$( rpm -qa | grep arm64 ) 
                 if [[ -z "$check_correctness" ]]; then 
-                      echo "{{ CorrectPackageAccToArch }}"
+                      echo "{{ Correct_Package_Acc_To_Arch }}"
                 else
-                      echo " {{ IncorrectPackageAccToArch }}"                                                               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 or x86-64 as a substring. Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
+                      echo " {{ Incorrect_Package_Acc_To_Arch }}"                                                               ## This if block refers to the check for the client packages of x86-64 architecture type. The client packages of x86-64 architecture type don't contain arm64 or x86-64 as a substring. Example client package: "rhui-azure-rhel9-eus-2.3-655.noarch","rhui-azure-rhel9-2.3-655.noarch"
                 fi 
           fi                            
   register: output_package_acc_architecture
@@ -66,10 +66,10 @@
 - name: "Write to error msg if incorrect client package is present according to the architecture"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n {{ IncorrectPackageAccToArch }}"
+    line: "\n {{ Incorrect_Package_Acc_To_Arch }}"
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ("{{ IncorrectPackageAccToArch }}" in output_package_acc_architecture.stdout_lines)  
+  when: ( offer_type!='byol') and ("{{ Incorrect_Package_Acc_To_Arch }}" in output_package_acc_architecture.stdout_lines)  
 
 
 
@@ -80,14 +80,14 @@
           client_package=$( rpm -qa | grep rhui )                                                                           ## Value of client package is getting calculated
           if [[ "{{ architecture }}" -eq "arm64" ]]; then                              
               substring="arm64-"                                                       
-              clientpkgwithoutarchitecture="${client_package//$substring/}"                                                 ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
-              client_package=$clientpkgwithoutarchitecture                            
+              client_pkg_without_architecture="${client_package//$substring/}"                                                 ## The arm64 substing is removed so that common validation logic can be used for the client packages of both the types of architectures.
+              client_package=$client_pkg_without_architecture                            
           fi                            
                                                           
                       
-              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                            ## Eliminate the suffix  "-2.3-5343.noarch.rpm"  from client package. Remaining value should be equal to "rhui-azure-rhel8" + "offertype" | Examples: "rhui-azure-rhel8", "rhui-azure-rhel8-eus", "rhui-azure-rhel8-sap-ha"
-              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                       ## Extract prefix rhui-azure-rhel8"  value from client package
-              extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                   ## For Base Offertype, extract_offer_val should be equal to null.
+              package_type=$(echo $client_package | sed 's/-[0-9]\+\.[0-9]\+-[0-9]\+\.noarch//')                               ## Eliminate the suffix  "-2.3-5343.noarch.rpm"  from client package. Remaining value should be equal to "rhui-azure-rhel8" + "offertype" | Examples: "rhui-azure-rhel8", "rhui-azure-rhel8-eus", "rhui-azure-rhel8-sap-ha"
+              prefix=$(echo $client_package | sed -E 's/^([^-]+-[^-]+-[^-]+)-.*/\1/')                                          ## Extract prefix rhui-azure-rhel8"  value from client package
+              extract_offer_val=$(echo $package_type | sed "s/$prefix//")                                                      ## For Base Offertype, extract_offer_val should be equal to null.
 
 
               offertype={{ offer_type }}
@@ -99,16 +99,16 @@
   
               if [[  $offertype  == "base" ]]; then
                   if [[ -z "$extract_offer_val" ]]; then 
-                        echo "{{ CorrectPackageAccToOffer }}"
+                        echo "{{ Correct_Package_Acc_To_Offer }}"
                   else
-                        echo "{{ IncorrectPackageAccToOffer }}"                                                             ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of Base Offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
+                        echo "{{ Incorrect_Package_Acc_To_Offer }}"                                                             ## This if block refers to the check for the base offertype which is supplied through pipeline variables. The value of extract_offer_val variable should be null. Example of Base Offertype client package "rhui-azure-rhel9-2.3-655.noarch". It does not contain the value of any offertype of RHEL Images.
                   fi   
 
               else    
                   if [[ $offertype == $extract_offer_val ]]; then 
-                        echo "{{ CorrectPackageAccToOffer }}"
+                        echo "{{ Correct_Package_Acc_To_Offer }}"
                   else
-                        echo "{{ IncorrectPackageAccToOffer }}"                                                             ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null. Example of client package other than Base Offertype: "rhui-azure-rhel9-eus-2.3-655.noarch" .
+                        echo "{{ Incorrect_Package_Acc_To_Offer }}"                                                             ## This else block refers to the check for the remaining offertypes which is supplied through pipeline variables. The value of extract_offer_val variable should not be null. Example of client package other than Base Offertype: "rhui-azure-rhel9-eus-2.3-655.noarch" .
                   fi   
               fi
 
@@ -121,8 +121,8 @@
 - name: "Write to error msg if incorrect client package is present according to the offertype"
   lineinfile:
     path: "{{err_folder}}/err_msgs.log"
-    line: "\n {{ IncorrectPackageAccToOffer }}"
+    line: "\n {{ Incorrect_Package_Acc_To_Offer }}"
     create: yes
     state: present 
-  when: ( offer_type!='byol') and ("{{ IncorrectPackageAccToOffer }}" in output_offertype_except_byol.stdout_lines)  
+  when: ( offer_type!='byol') and ("{{ Incorrect_Package_Acc_To_Offer }}" in output_offertype_except_byol.stdout_lines)  
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?

- This PR is required to add validation for client packages which are present in the RHEL Images against the offertype of the Image. Through this validation, it will check if the client package is correct according to the offertype of the RHEL Image.

## What changes have been made?

- Added ansible tasks in ansible_image_validation\validation-playbooks\per-vm-validation.yaml file.

## Manual Validation of the ansible task added:
[Task 27460557]([Task 27460557](https://msazure.visualstudio.com/One/_workitems/edit/27460557): Create a BVT setup of RHEL9 VM and perform validation of ansible image pipeline validation tasks.)


## Successful pipeline runs:
- Case where offertype is BYOL: 
-  https://msazure.visualstudio.com/One/_build/results?buildId=101219604&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=fde4920a-1d48-5df3-2e54-463303c3bf36&l=428

-  Case where Correct client package is present according to offertype: 
  - https://msazure.visualstudio.com/One/_build/results?buildId=101214754&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=fde4920a-1d48-5df3-2e54-463303c3bf36&l=475

-  Case where incorrect client package is present according to offertype: 
  - https://msazure.visualstudio.com/One/_build/results?buildId=101214795&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=fde4920a-1d48-5df3-2e54-463303c3bf36
