### PR TITLE
Correction in the accelerated networking task of ansible validation.

### DIFF
--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -142,7 +142,7 @@
     when: rhui_package_count != "0"
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.
-  when: ansible_distribution_major_version == '9'
+  when: isCVM is false and ansible_distribution_major_version == '9'
   block:
     - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
       shell: NetworkManager --print-config

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -142,7 +142,7 @@
     when: rhui_package_count != "0"
 
 - name: Check for the Accelerated Networking in Rhel 9 Images.
-  when: isCVM is false and ansible_distribution_major_version == '9'
+  when: ansible_distribution_major_version == '9'
   block:
     - name: Check if the unmanaged devices are present network config of all Rhel 9 Images
       shell: NetworkManager --print-config

--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -157,7 +157,7 @@
         line: "\n Accelerated Networking Validation failed since unmanaged drivers are not present."
         create: yes
         state: present 
-      when: ("driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
+      when: ("unmanaged-devices=driver:mlx4_core;driver:mlx5_core" not in check_network_config.stdout_lines)    
     
     - name: Check if the accelerated networking config file is present in all Rhel 9 Images
       stat:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?

- The conditional evaluation of accelerated networking task is failing in the ansible validation task in the image build pipeline. https://msazure.visualstudio.com/One/_build/results?buildId=88605990&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=fde4920a-1d48-5df3-2e54-463303c3bf36&l=811

- Therefore, a change is made to pass the ansible validation when unmanaged devices are present in the rhel 9 images.

![image](https://github.com/Azure/linux-image-validations/assets/112065840/21bdc76b-8c27-4168-b6e3-fc38b0181281)

![image](https://github.com/Azure/linux-image-validations/assets/112065840/55cef669-4deb-4d21-aeb9-284782c63abb)


## What changes have been made?
Following file is changed:

- linux-image-validations\ansible_image_validation\validation-playbooks\per-vm-validation.yaml


## Successful Pipeline Link (optional):
- Link to the successful pipeline run (if any) : https://msazure.visualstudio.com/One/_build/results?buildId=88900444&view=logs&j=cf9b4744-03ec-55e8-80bd-eb3063bd903c&t=fde4920a-1d48-5df3-2e54-463303c3bf36&l=428

- ![image](https://github.com/Azure/linux-image-validations/assets/112065840/82cafec8-4ab4-4fbe-a9c8-0add44e92a37)


