### PR TITLE
Update per-vm-validation.yaml

### DIFF
--- a/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
+++ b/ansible_image_validation/validation-playbooks/per-vm-validation.yaml
@@ -30,9 +30,18 @@
   register: users_on_machine
   ignore_errors: yes
 
-- name: Collect list of all installed packages
-  package_facts:
-    manager: "auto"
+- name: Execute command to list packages
+  shell: |
+    package_list=$( rpm -qa --qf ' "%{NAME}": { "version": " %{VERSION}", "release": "%{RELEASE}" \},' )
+    package_list=${package_list%,}
+    package_json="{  $package_list  }"
+    echo $package_json | jq -r .
+  register: package_list_output
+
+- name: Set package facts
+  set_fact:
+    ansible_facts:
+      packages: "{{ package_list_output.stdout | from_json }}"
 
 - name: Check if cloud-init is installed
   lineinfile:
@@ -108,9 +117,18 @@
 
 - name: Check for Rhui client package in the image
   block:
-  - name: Gather the package facts
-    ansible.builtin.package_facts:
-      manager: auto
+  - name: Execute command to list packages
+    shell: |
+      package_list=$( rpm -qa --qf ' "%{NAME}": { "version": " %{VERSION}", "release": "%{RELEASE}" \},' )
+      package_list=${package_list%,}
+      package_json="{ $package_list }"
+      echo $package_json | jq -r .
+    register: package_list_output
+
+  - name: Set package facts
+    set_fact:
+      ansible_facts:
+        packages: "{{ package_list_output.stdout | from_json }}"
 
   - name: Check for rhui package details
     set_fact:


### PR DESCRIPTION
using another method to check existing packages as current methods is not supported for 8.10 version,

<!-- DO NOT DELETE THIS TEMPLATE -->

## Why is this PR required?
<!--
Please add an informative description that covers that changes made by the pull request.
-->
Bug in the ansible step 
name: Collect list of all installed packages
  package_facts:
    manager: "auto"
   
package_facts library uses python spawn function that picks up system installation of python rather than installation path specified in inventory.ini file, this makes this library incompatible with RHEL8.10 and older version of image which had python version less than 3.7, 

RHEL 8.10 with python Version 3.6 do not support future annotation which is expected by the latest version of ansible,
This is an old issue but till date no bug fix is deployed in ansible,


## What changes have been made?
I have used bash command to achieve the exact same thing, this let us bypass the bug in ansible library,

## References:
https://github.com/ansible/ansible/issues/82068
This discussion defines the issue

